### PR TITLE
Add optional label policy

### DIFF
--- a/policies/image/policy/optional-labels.rego
+++ b/policies/image/policy/optional-labels.rego
@@ -1,0 +1,13 @@
+package main
+
+deny[msg] {
+    not input.Labels["maintainer"]
+
+    msg := "The maintainer label should be defined"
+}
+
+deny[msg] {
+    not input.Labels["summary"]
+
+    msg := "The summary label should be defined"
+}


### PR DESCRIPTION
This adds a policy for optional labels `maintainer` and `summary` for HACBS-201