### PR TITLE
[HACBS-74]-adding clair vulnerability policies

### DIFF
--- a/policies/clair/vulnerabilities-check.rego
+++ b/policies/clair/vulnerabilities-check.rego
@@ -1,0 +1,30 @@
+package main
+
+deny[msg] {
+  rpms_with_critical_vulnerabilities := {rpm.Name | rpm := input.data[_].Features[_]; count(rpm.Vulnerabilities) > 0; rpm.Vulnerabilities[_].Severity == "Critical"}
+  not count(rpms_with_critical_vulnerabilities) == 0
+
+  msg = sprintf("The packages musn't have any critical vulnerabilities! Packages with critical vulnerabilities: %s", [concat(", ", rpms_with_critical_vulnerabilities)])
+}
+
+deny[msg] {
+  rpms_with_high_vulnerabilities := {rpm.Name | rpm := input.data[_].Features[_]; count(rpm.Vulnerabilities) > 0; rpm.Vulnerabilities[_].Severity == "High"}
+  not count(rpms_with_high_vulnerabilities) == 0
+
+  msg = sprintf("The packages musn't have any high vulnerabilities! Packages with high vulnerabilities: %s", [concat(", ", rpms_with_high_vulnerabilities)])
+}
+
+deny[msg] {
+  rpms_with_medium_vulnerabilities := {rpm.Name | rpm := input.data[_].Features[_]; count(rpm.Vulnerabilities) > 0; rpm.Vulnerabilities[_].Severity == "Medium"}
+  not count(rpms_with_medium_vulnerabilities) == 0
+
+  msg = sprintf("The packages musn't have any medium vulnerabilities! Packages with medium vulnerabilities: %s", [concat(", ", rpms_with_medium_vulnerabilities)])
+}
+
+deny[msg] {
+  rpms_with_low_vulnerabilities := {rpm.Name | rpm := input.data[_].Features[_]; count(rpm.Vulnerabilities) > 0; rpm.Vulnerabilities[_].Severity == "Low"}
+  not count(rpms_with_low_vulnerabilities) == 0
+
+  msg = sprintf("The packages musn't have any low vulnerabilities! Packages with low vulnerabilities: %s", [concat(", ", rpms_with_low_vulnerabilities)])
+}
+


### PR DESCRIPTION
Rego file consisting of vulnerabilities check:
Sample output:

`./conftest test --policy clair-vulns.rego test-index.json -o json`
```[
        {
                "filename": "test-index.json",
                "namespace": "main",
                "successes": 1,
                "failures": [
                        {
                                "msg": "The packages musn't have any high vulnerabilities! Packages with high vulnerabilities: bind-libs, bind-libs-lite, bind-license, bind-utils, glib2, gnutls, nettle, openssl-libs, python3-bind, systemd, systemd-libs, systemd-pam"
                        },
                        {
                                "msg": "The packages musn't have any low vulnerabilities! Packages with low vulnerabilities: bash, libdb, libdb-utils, libpcap, openssl-libs, systemd, systemd-libs, systemd-pam"
                        },
                        {
                                "msg": "The packages musn't have any medium vulnerabilities! Packages with medium vulnerabilities: bind-libs, bind-libs-lite, bind-license, bind-utils, brotli, cryptsetup-libs, curl, cyrus-sasl-lib, expat, glib2, glibc, glibc-common, glibc-minimal-langpack, gnupg2, gnutls, krb5-libs, libarchive, libcurl, libgcrypt, libsolv, libssh, libssh-config, libxml2, lz4-libs, p11-kit, p11-kit-trust, pcre2, platform-python, platform-python-pip, python3-bind, python3-gobject-base, python3-libs, python3-libxml2, python3-pip, python3-pip-wheel, python3-rpm, rpm, rpm-build-libs, rpm-libs, sqlite-libs, systemd, systemd-libs, systemd-pam, vim-minimal"
                        }
                ]
        }
]
```


There is also fifth type of vulnerability: `Unknown` but it is not currently something that needs to be taken care of at the moment.