### PR TITLE
Proposal: Refactor the policy structure

### DIFF
--- a/policies/clair/vulnerabilities-check.rego
+++ b/policies/clair/vulnerabilities-check.rego
@@ -1,4 +1,4 @@
-package main
+package required_checks
 
 violation_critical_vulnerabilities[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
   rpms_with_critical_vulnerabilities := {rpm.Name | rpm := input.data[_].Features[_]; count(rpm.Vulnerabilities) > 0; rpm.Vulnerabilities[_].Severity == "Critical"}

--- a/policies/image/deprecated-labels.rego
+++ b/policies/image/deprecated-labels.rego
@@ -1,4 +1,4 @@
-package main
+package required_checks
 
 violation_install_deprecated[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
   input.Labels["INSTALL"]

--- a/policies/image/optional-labels.rego
+++ b/policies/image/optional-labels.rego
@@ -1,4 +1,4 @@
-package main
+package optional_checks
 
 violation_maintainer_required[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
   not input.Labels["maintainer"]

--- a/policies/image/required-labels.rego
+++ b/policies/image/required-labels.rego
@@ -1,4 +1,4 @@
-package main
+package required_checks
 
 violation_name_required[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
   not input.Labels["name"]

--- a/policies/repository/deprecated-image.rego
+++ b/policies/repository/deprecated-image.rego
@@ -1,4 +1,4 @@
-package main
+package required_checks
 
 violation_image_repository_deprecated[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
   input.release_categories[_] == "Deprecated"

--- a/policies/rpm_manifest/unsigned-rpms.rego
+++ b/policies/rpm_manifest/unsigned-rpms.rego
@@ -1,4 +1,4 @@
-package main
+package required_checks
 
 violation_image_unsigned_rpms[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
   unsigned_rpms := {rpm.nvra | rpm := input.rpms[_]; not rpm.gpg}


### PR DESCRIPTION
* Split up the policies according to the data they test
* Set the required_checks and optional_checks packages

This is a proposal to put the policies into different directories according to the data that they are supposed to validate(`image`, `repository`, `clair`, `rpm_manifest`).
Additionally, this change proposes setting the package name for each policy to be either `required_checks` or `optional_checks` to allow differentiation when running them together from the same directory.