### PR TITLE
Add release-workflow to hacbs-test repo

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,14 @@
+Release Workflow:
+
+  We use Github actions workflow for our release process, which means when we are ready to release, we create a release/v1.2.3 from the main branch. Uses .github/workflows/release.yml to publish the release.
+  
+  Images are pushed to quay.io using the robot accounts credentials, Github and quay.io credentials managed in secret sections in the hacbs-test repo project settings. While triggering the release, the inputs are passed in GitHub event context to release the specific tag for the release version.
+  
+  Once the Image pushed to quay.io, the release section gets updated with the latest tag version in the hacbs-test repo.
+ 
+Triggering a release:
+  Select the Actions tab and choose release workflow from the list of workflows. 
+  Click on the Run Workflow event trigger.
+  Now enter the version to be released, already prefixed with `v`
+  Make sure the release branch specified as `main`
+  Click on Run Workflow to trigger the release.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,56 @@
+name: Release Workflow
+on:
+  workflow_dispatch:
+    inputs:
+      release-version:
+        description: 'Version being released, prefixed with v. Example: 1.2.3'
+        required: true
+      branch:
+        description: 'Branch to release from'
+        required: true
+        default: 'main'
+
+jobs:
+  build:
+    name: Build and push image
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build Image
+      id: build-image
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: hacbs-test
+        tags: latest v${{ github.event.inputs.release-version }} ${{ github.sha }}
+        containerfiles: |
+          ./Dockerfile
+    # Podman Login action (https://github.com/redhat-actions/podman-login) also be used to log in,
+    # in which case 'username' and 'password' can be omitted.
+    - name: Push To quay.io
+      id: push-to-quay
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ steps.build-image.outputs.image }}
+        tags: ${{ steps.build-image.outputs.tags }}
+        registry: quay.io/redhat-appstudio
+        username: ${{ secrets.HACBS_TEST_QUAY_USER }}
+        password: ${{ secrets.HACBS_TEST_QUAY_TOKEN }}
+
+    - name: Print image url
+      run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+
+    - name: Bump version and push tag
+      id: tag_version
+      uses: srivickynesh/github-tag-action@v6.0
+      with:
+        github_token: ${{ secrets.HACBS_TEST_GITHUB_TOKEN }}
+        custom_tag: ${{ github.event.inputs.release-version }}
+
+    - name: Create a GitHub release
+      uses: srivickynesh/release-action@v1
+      with:
+        tag: ${{ steps.tag_version.outputs.new_tag }}
+        name: ${{ steps.tag_version.outputs.new_tag }}
+        body: ${{ steps.tag_version.outputs.changelog }}


### PR DESCRIPTION
version - has to be specified while manually triggering the release workflow.
latest - points to latest image version.
sha - SHA256 digest


![Screenshot from 2022-05-04 13-11-01](https://user-images.githubusercontent.com/32717488/166640846-87c393af-cfe1-42dd-82c6-4877f0421116.png)


![Screenshot from 2022-05-04 13-28-54](https://user-images.githubusercontent.com/32717488/166642833-ab18988a-cb12-44b7-8ba7-28e03d51c621.png)


Signed-off-by: Sri Vignesh [sselvan@redhat.com](mailto:sselvan@redhat.com)