### PR TITLE
Add gosec to hacbs-test Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN curl -L https://github.com/open-policy-agent/conftest/releases/download/v"${
     curl -L https://go.dev/dl/go"${go_version}".linux-amd64.tar.gz | tar -xz --no-same-owner -C /usr/local/ && \
     curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b /usr/local/go/bin v"${gosec_version}" && \
     dnf -y --setopt=tsflags=nodocs install \
-    git \
     jq \
     skopeo 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM registry.access.redhat.com/ubi8/ubi
 
 ARG conftest_version=0.30.0
 ARG BATS_VERSION=1.6.0
+ARG go_version=1.18.1
+ARG gosec_version=2.11.0
 
 ENV POLICY_PATH="/project"
 
@@ -12,9 +14,14 @@ RUN curl -L https://github.com/open-policy-agent/conftest/releases/download/v"${
     cd "bats-core-$BATS_VERSION" && \
     ./install.sh /usr && \
     cd .. | rm -rf "bats-core-$BATS_VERSION" | rm -rf "v$BATS_VERSION.tar.gz" && \
+    curl -L https://go.dev/dl/go"${go_version}".linux-amd64.tar.gz | tar -xz --no-same-owner -C /usr/local/ && \
+    curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b /usr/local/go/bin v"${gosec_version}" && \
     dnf -y --setopt=tsflags=nodocs install \
+    git \
     jq \
     skopeo 
+
+ENV PATH $PATH:/usr/local/go/bin
 
 COPY policies $POLICY_PATH
 COPY test $POLICY_PATH


### PR DESCRIPTION
This adds prerequisites for HACBS-223 (go, gosec and git (for git cloning the source repo)).