### PR TITLE
feat: [HACBS-337] adding oc binary and clamav package to worker image…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ARG BATS_VERSION=1.6.0
 ENV POLICY_PATH="/project"
 
 RUN curl -L https://github.com/open-policy-agent/conftest/releases/download/v"${conftest_version}"/conftest_"${conftest_version}"_Linux_x86_64.tar.gz | tar -xz --no-same-owner -C /usr/bin/ && \
+    curl https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz --output oc.tar.gz && tar -xzvf oc.tar.gz -C /usr/bin && \
     curl -LO "https://github.com/bats-core/bats-core/archive/refs/tags/v$BATS_VERSION.tar.gz" && \
     tar -xf "v$BATS_VERSION.tar.gz" && \
     cd "bats-core-$BATS_VERSION" && \
@@ -14,7 +15,12 @@ RUN curl -L https://github.com/open-policy-agent/conftest/releases/download/v"${
     cd .. | rm -rf "bats-core-$BATS_VERSION" | rm -rf "v$BATS_VERSION.tar.gz" && \
     dnf -y --setopt=tsflags=nodocs install \
     jq \
-    skopeo 
+    skopeo \
+    https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
+    dnf -y --setopt=tsflags=nodocs install \
+    clamav \
+    clamd \
+    clamav-update
 
 COPY policies $POLICY_PATH
 COPY test/conftest.sh $POLICY_PATH

--- a/clamav/Dockerfile
+++ b/clamav/Dockerfile
@@ -1,0 +1,8 @@
+FROM registry.access.redhat.com/ubi8/ubi
+RUN dnf -y --setopt=tsflags=nodocs install \
+    https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
+    dnf -y --setopt=tsflags=nodocs install \
+    clamav \
+    clamd \
+    clamav-update
+RUN freshclam


### PR DESCRIPTION
…, Dockerfile for clamav-db sidecar

OC binary is being fetched from public repo with latest version.
ClamAV-db Dockerfile is running freshclam during image build, no further steps are needed.
Added ClamAV clamscan to the worker image so it can execute scans on compiled code.