### PR TITLE
fix[HACBS-840] provide space for docker build

### DIFF
--- a/.github/workflows/clair-in-ci-db.yaml
+++ b/.github/workflows/clair-in-ci-db.yaml
@@ -22,17 +22,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install qemu dependency
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static
-
       - name: Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.HACBS_TEST_QUAY_USER }}
           password: ${{ secrets.HACBS_TEST_QUAY_TOKEN }}
+      
+      - name: Setup docker for workflow
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - name: Pull-and-retag-image
         run: |
@@ -40,20 +42,9 @@ jobs:
           docker tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }} ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.PREVIOUS_TAG }}
           docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.PREVIOUS_TAG }}
 
-      - name: Build-image
-        id: build-image
-        uses: redhat-actions/buildah-build@v2
-        with:
-          image: ${{ env.IMAGE_NAME }}
-          tags: ${{ env.LATEST_TAG }}
-          archs: amd64,ppc64le
-          containerfiles: |
-            ./clair-in-ci/Dockerfile
+      - name: Build-and-push-image
+        id: build-and-push-image
+        run: |
+          docker build . -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }} -f ./clair-in-ci/Dockerfile
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }}
 
-      - name: Push-to-${{ env.REGISTRY }}
-        id: push-to-quay
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          image: ${{ steps.build-image.outputs.image }}
-          tags: ${{ steps.build-image.outputs.tags }}
-          registry: ${{ env.REGISTRY }}


### PR DESCRIPTION
Multiple reasons why the build image was not passing throught a workflow job:

Since the scale of build image exceeded 11GB, it was unable to finish the build process (no space left on device).
This problem persisted even though the enough space was provided. 
Removing `buildah` section helped to solve this issue together with adding some space within the github runner.
We also don't need to provide a support for multiple architectures at this time, hence the removal of qemu.

Maybe worth mentioning adding this github action https://github.com/marketplace/actions/free-disk-space-ubuntu
in near future.