### PR TITLE
feat(HACBS-1386): a script to parse hacbs test result

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ COPY test/conftest.sh $POLICY_PATH
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY test/entrypoint.sh /entrypoint.sh
+COPY test/utils.sh /utils.sh
 
 # Code file to execute when the docker container starts up (`entrypoint.sh`)
 ENTRYPOINT ["/entrypoint.sh"]

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -26,5 +26,13 @@ curl -X 'GET' 'https://catalog.redhat.com/api/containers/v1/repositories/registr
 skopeo inspect --no-tags docker://quay.io/redhat-appstudio/application-service-catalog:next > fbc_label.json
 check_return_code
 
+# Test parse_hacbs_test_output
+echo "Testing shell function parse_hacbs_test_output"
+. /utils.sh
+conftest test --namespace optional_checks --policy $POLICY_PATH/image/inherited-labels.rego label.json --output=json > unittest.json
+HACBS_TEST_OUTPUT=
+parse_hacbs_test_output sanity_label_check conftest unittest.json
+[ "$(echo $HACBS_TEST_OUTPUT | jq -r '.result')" == "SUCCESS" ] && echo "test_parse_hacbs_test_output PASSED" || exit 1
+
 echo "Starting Integeration-Tests"
 bats $POLICY_PATH/conftest.sh

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -1,0 +1,67 @@
+#!/bin/sh -l
+
+# Parse test result and genarate HACBS_TEST_OUTPUT
+parse_hacbs_test_output() {
+  # The name of test
+  TEST_NAME=$1
+  # The format of json file, can be conftest or sarif
+  TEST_RESULT_FORMAT=$2
+  # The json file to parse
+  TEST_RESULT_FILE=$3
+
+  if [ -z "$TEST_NAME" ]; then
+    echo Missing parameter TEST_NAME
+    exit 1
+  fi
+  if [ -z "$TEST_RESULT_FORMAT" ]; then
+    echo Missing parameter TEST_RESULT_FORMAT
+    exit 1
+  fi
+  if [ -z "$TEST_RESULT_FILE" ]; then
+    echo Missing parameter TEST_RESULT_FILE
+    exit 1
+  fi
+
+  if [ ! -f "$TEST_RESULT_FILE" ]; then
+    echo "File $TEST_RESULT_FILE doesn't exist"
+    exit 1
+  fi
+
+  # Handle the test result with format of sarif
+  if [ "$TEST_RESULT_FORMAT" = "sarif" ]; then
+    HACBS_TEST_OUTPUT=$(jq -rce --arg date $(date +%s)  \
+      '{ result: (if (.runs[].results | length > 0) then "FAILURE" else "SUCCESS" end),
+               timestamp: $date,
+               namespace: "default",
+               successes: 0,
+               note: "",
+               failures: (.runs[].results | length)
+             }' $TEST_RESULT_FILE || true)
+
+    # Log out the failing runs
+    if [ $(echo $HACBS_TEST_OUTPUT | jq '.failures') -gt 0 ]
+    then
+      echo "The $TEST_NAME test has failed with the following issues:"
+      jq '.runs[].results // []|map(.message.text) | unique' $TEST_RESULT_FILE
+    fi
+  # Handle the test result with format of conftest
+  elif [ "$TEST_RESULT_FORMAT" = "conftest" ]; then
+    HACBS_TEST_OUTPUT=$(jq -rce --arg date $(date +%s) \
+      '.[] | { result: (if (.failures | length > 0) then "FAILURE" else "SUCCESS" end),
+               timestamp: $date,
+               namespace,
+               successes,
+               failures: (.failures | length)
+             }' $TEST_RESULT_FILE || true)
+
+    # Log out the failing runs
+    if [ $(echo $HACBS_TEST_OUTPUT | jq '.failures') -gt 0 ]
+    then
+      echo "The $TEST_NAME test has failed with the following issues::"
+      jq '.[].failures // []|map(.metadata.details.name) | unique' $TEST_RESULT_FILE
+    fi    
+  else
+    echo "Unsupported TEST_RESULT_FORMAT $TEST_RESULT_FORMAT"
+    exit 1
+  fi
+}


### PR DESCRIPTION
 Add a function to parse hacbs test result to generate $HACBS_TEST_OUTPUT
 and log out failed tests

Signed-off-by: Hongwei Liu hongliu@redhat.com