### PR TITLE
feat(HACBS-1598): Remove unused function `make_error_result_json`

### DIFF
--- a/test/utils.sh
+++ b/test/utils.sh
@@ -83,16 +83,6 @@ make_result_json() {
 }
 
 
-# Return HACBS_TEST_OUTPUT error response
-make_error_result_json(){
-  # Note about error result for user
-  local NOTE="$1"
-  # Conftest namespace (should be empty in testcases without conftest)
-  local NAMESPACE="$2"
-  make_result_json -r 'ERROR' -t "${NOTE}" -n "${NAMESPACE}"
-}
-
-
 # Parse test result and genarate HACBS_TEST_OUTPUT
 parse_hacbs_test_output() {
   # The name of test

--- a/unittests_bash/test_utils.bats
+++ b/unittests_bash/test_utils.bats
@@ -63,12 +63,6 @@ setup() {
     test_json_eq "${EXPECTED_JSON}" "${output}"
 }
 
-@test "Error result: default" {
-    run make_error_result_json "Something is wrong" "testnamespace"
-    EXPECTED_JSON='{"result":"ERROR","timestamp":"whatever","note":"Something is wrong","namespace":"testnamespace","successes":0,"failures":0,"warnings":0}'
-    test_json_eq "${EXPECTED_JSON}" "${output}"
-}
-
 @test "Conftest input: successful tests" {
     HACBS_TEST_OUTPUT=""
     parse_hacbs_test_output testname conftest unittests_bash/data/conftest_successes.json


### PR DESCRIPTION
At the end this function is unused, removing dead code

Signed-off-by: Martin Basti <mbasti@redhat.com>