### PR TITLE
fix(Dockerfile) remove unused tar.gz archive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG cyclonedx_version=0.24.2
 ENV POLICY_PATH="/project"
 
 RUN ARCH=$(uname -m) && curl -L https://github.com/open-policy-agent/conftest/releases/download/v"${conftest_version}"/conftest_"${conftest_version}"_Linux_"$ARCH".tar.gz | tar -xz --no-same-owner -C /usr/bin/ && \
-    curl https://mirror.openshift.com/pub/openshift-v4/"$ARCH"/clients/ocp/stable/openshift-client-linux.tar.gz --output oc.tar.gz && tar -xzvf oc.tar.gz -C /usr/bin && \
+    curl https://mirror.openshift.com/pub/openshift-v4/"$ARCH"/clients/ocp/stable/openshift-client-linux.tar.gz --output oc.tar.gz && tar -xzvf oc.tar.gz -C /usr/bin && rm oc.tar.gz && \
     curl -LO "https://github.com/bats-core/bats-core/archive/refs/tags/v$BATS_VERSION.tar.gz" && \
     curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py" && \
     tar -xf "v$BATS_VERSION.tar.gz" && \


### PR DESCRIPTION
oc.tar.gzip archive is not needed anymore after isntallation, removing it saves about 51MB of the image size

Signed-off-by: Martin Basti <mbasti@redhat.com>