### PR TITLE
fix(CI): run image builds conditionaly

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -83,12 +83,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install qemu dependency
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            clamav:
+              - 'clamav/**'
+
+      - if: steps.changes.outputs.clamav == 'true'
+        name: Install qemu dependency
         run: |
           sudo apt-get update
           sudo apt-get install -y qemu-user-static
 
-      - name: Build-image
+      - if: steps.changes.outputs.clamav == 'true'
+        name: Build-image
         id: build-image
         uses: redhat-actions/buildah-build@v2
         with:
@@ -105,14 +114,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Setup docker for workflow
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            clair:
+              - 'clair-in-ci/**'
+
+      - if: steps.changes.outputs.clair == 'true'
+        name: Setup docker for workflow
         run: |
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
           sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
-      - name: Build-image
+      - if: steps.changes.outputs.clair == 'true'
+        name: Build-image
         id: build-image
         run: |
           docker build . -t clair-in-ci-db:pr-test -f ./clair-in-ci/Dockerfile


### PR DESCRIPTION
building clamav and clair image takes long time, run tests only when there were changes related to those images

Signed-off-by: Martin Basti <mbasti@redhat.com>