### PR TITLE
clair: Update Dockerfile to build DB

### DIFF
--- a/clair-in-ci/Dockerfile
+++ b/clair-in-ci/Dockerfile
@@ -1,3 +1,3 @@
-FROM quay.io/crozzy/clair-action:v0
-RUN microdnf install wget zstd -y && wget -q https://clair-sqlite-db.s3.amazonaws.com/matcher.zst && zstd -o /tmp/matcher.db -d matcher.zst && rm -f matcher.zst && \
-    microdnf clean all
+FROM quay.io/projectquay/clair-action:v0.0.3
+
+RUN DB_PATH=/tmp/matcher.db /bin/clair-action update


### PR DESCRIPTION
Addressing https://issues.redhat.com/browse/PROJQUAY-4878 this removes the pre-compiled DB fetch and forces the container to do the DB creation. This is required as the infra for serving the pre-compiled DB is going away. Also, update the clair-action version. This will increase the time it takes to produce the image as it will be reaching out directly to Clair's sources, but given it is run daily that shouldn't be an issue. This also means that errors in the update cycle will be transparent in the Actions instead of hidden (as they are now).

Signed-off-by: crozzy <joseph.crosland@gmail.com>