### PR TITLE
fix(HACBS-1755) add pinned opm version from gh repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,14 @@ FROM registry.access.redhat.com/ubi8/ubi:8.7-1054.1675788412
 ARG conftest_version=0.33.2
 ARG BATS_VERSION=1.6.0
 ARG cyclonedx_version=0.24.2
+ARG OPM_VERSION=v1.26.3
 
 ENV POLICY_PATH="/project"
 
 RUN ARCH=$(uname -m) && curl -L https://github.com/open-policy-agent/conftest/releases/download/v"${conftest_version}"/conftest_"${conftest_version}"_Linux_"$ARCH".tar.gz | tar -xz --no-same-owner -C /usr/bin/ && \
     curl https://mirror.openshift.com/pub/openshift-v4/"$ARCH"/clients/ocp/stable/openshift-client-linux.tar.gz --output oc.tar.gz && tar -xzvf oc.tar.gz -C /usr/bin && rm oc.tar.gz && \
     curl -LO "https://github.com/bats-core/bats-core/archive/refs/tags/v$BATS_VERSION.tar.gz" && \
+    curl -L https://github.com/operator-framework/operator-registry/releases/download/"${OPM_VERSION}"/linux-amd64-opm > /usr/bin/opm && chmod +x /usr/bin/opm && \ 
     curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py" && \
     tar -xf "v$BATS_VERSION.tar.gz" && \
     cd "bats-core-$BATS_VERSION" && \


### PR DESCRIPTION
Including pinned version of OPM from verified source.
Version : v1.26.3