### PR TITLE
feat(PROJQUAY-5085): use clair-action with lower logging

### DIFF
--- a/clair-in-ci/Dockerfile
+++ b/clair-in-ci/Dockerfile
@@ -1,3 +1,4 @@
-FROM quay.io/projectquay/clair-action:v0.0.3
+FROM quay.io/projectquay/clair-action:v0.0.4
 
-RUN DB_PATH=/tmp/matcher.db /bin/clair-action update
+# Update the matcher database. Use the info log level to track sources
+RUN DB_PATH=/tmp/matcher.db /bin/clair-action --level info update


### PR DESCRIPTION
* Use quay.io/projectquay/clair-action:v0.0.4 version
* Set the log level to 'info' when running update
* Info logs produce ~2k lines, used for tracking sources