### PR TITLE
clair: Free space for Clair to create DB

### DIFF
--- a/.github/workflows/clair-in-ci-db.yaml
+++ b/.github/workflows/clair-in-ci-db.yaml
@@ -41,6 +41,7 @@ jobs:
           docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }}
           docker tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }} ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.PREVIOUS_TAG }}
           docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.PREVIOUS_TAG }}
+          docker rmi -f $(docker images -q)
 
       - name: Build-and-push-image
         id: build-and-push-image


### PR DESCRIPTION
Currently the runner is running out of space because it is pulling down a image first and retagging it. This should delete that image after the retagging and give Clair enough space to do the update.