### PR TITLE
fix(HACBS-1929): delete a label check policy

### DIFF
--- a/policies/image/required-labels.rego
+++ b/policies/image/required-labels.rego
@@ -72,15 +72,6 @@ violation_architecture_required[{"msg": msg, "details":{"name": name, "descripti
   url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
 }
 
-violation_com_redhat_build_host_required[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
-  not input.Labels["com.redhat.build-host"]
-
-  name := "com_redhat_build_host_label_required"
-  msg := "The required 'com.redhat.build-host' label is missing!"
-  description := "The build host used to create an image for internal use and auditability, similar to the use in RPM."
-  url := "https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/guide_to_layered_image_build_service_osbs#jive_content_id_Labels"
-}
-
 violation_vendor_required[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
   not input.Labels["vendor"]
 

--- a/unittests/test_images/required-labels_test.rego
+++ b/unittests/test_images/required-labels_test.rego
@@ -50,12 +50,6 @@ test_violation_architecture_required {
     result[_].msg == "The required 'architecture' label is missing!"
 }
 
-test_violation_com_redhat_build_host_required {
-    result := violation_com_redhat_build_host_required with input as image
-    result[_].details.name == "com_redhat_build_host_label_required"
-    result[_].msg == "The required 'com.redhat.build-host' label is missing!"
-}
-
 test_violation_vendor_required {
     result := violation_vendor_required with input as image
     result[_].details.name == "vendor_label_required"


### PR DESCRIPTION
Fixes [HACBS-1929](https://issues.redhat.com/browse/HACBS-1929)

Delete the policy which mandates the presence of the `com.redhat.build-host` label during the sanity-labels taskrun.