### PR TITLE
fix(stoneintg-358|stonebugs-42):drop URL & report number of vulns

### DIFF
--- a/policies/clair/vulnerabilities-check.rego
+++ b/policies/clair/vulnerabilities-check.rego
@@ -1,42 +1,45 @@
 package required_checks
 
-violation_critical_vulnerabilities[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
+violation_critical_vulnerabilities[{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] {
   rpms_with_critical_vulnerabilities := {rpm.Name | rpm := input.data[_].Features[_]; count(rpm.Vulnerabilities) > 0; rpm.Vulnerabilities[_].Severity == "Critical"}
   not count(rpms_with_critical_vulnerabilities) == 0
 
   name := "clair_critical_vulnerabilities"
-  msg = sprintf("Found packages with critical vulnerabilities: %s", [concat(", ", rpms_with_critical_vulnerabilities)])
-  description := "The image musn't contain packages that have critical severity vulnerabilities."
-  url := "https://source.redhat.com/groups/public/product-security/content/product_security_folder/understanding_red_hat_security_vulnerabilities_10pdf"
+  vulns_num = count(rpms_with_critical_vulnerabilities)
+  msg := "Found packages with critical vulnerabilities. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
+  description = sprintf("Packages found: %s", [concat(", ", rpms_with_critical_vulnerabilities)])
+  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 }
 
-violation_high_vulnerabilities[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
+violation_high_vulnerabilities[{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] {
   rpms_with_high_vulnerabilities := {rpm.Name | rpm := input.data[_].Features[_]; count(rpm.Vulnerabilities) > 0; rpm.Vulnerabilities[_].Severity == "High"}
   not count(rpms_with_high_vulnerabilities) == 0
 
   name := "clair_high_vulnerabilities"
-  msg = sprintf("Found packages with high vulnerabilities: %s", [concat(", ", rpms_with_high_vulnerabilities)])
-  description := "The image musn't contain packages that have high severity vulnerabilities."
-  url := "https://source.redhat.com/groups/public/product-security/content/product_security_folder/understanding_red_hat_security_vulnerabilities_10pdf"
+  vulns_num = count(rpms_with_high_vulnerabilities)
+  msg := "Found packages with high vulnerabilities. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
+  description = sprintf("Packages found: %s", [concat(", ", rpms_with_high_vulnerabilities)])
+  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 }
 
-violation_medium_vulnerabilities[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
+violation_medium_vulnerabilities[{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] {
   rpms_with_medium_vulnerabilities := {rpm.Name | rpm := input.data[_].Features[_]; count(rpm.Vulnerabilities) > 0; rpm.Vulnerabilities[_].Severity == "Medium"}
   not count(rpms_with_medium_vulnerabilities) == 0
 
   name := "clair_medium_vulnerabilities"
-  msg = sprintf("Found packages with medium vulnerabilities: %s", [concat(", ", rpms_with_medium_vulnerabilities)])
-  description := "The image musn't contain packages that have medium severity vulnerabilities."
-  url := "https://source.redhat.com/groups/public/product-security/content/product_security_folder/understanding_red_hat_security_vulnerabilities_10pdf"
+  vulns_num = count(rpms_with_medium_vulnerabilities)
+  msg := "Found packages with medium vulnerabilities. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
+  description = sprintf("Packages found: %s", [concat(", ", rpms_with_medium_vulnerabilities)])
+  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 }
 
-violation_low_vulnerabilities[{"msg": msg, "details":{"name": name, "description": description, "url": url}}] {
+violation_low_vulnerabilities[{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] {
   rpms_with_low_vulnerabilities := {rpm.Name | rpm := input.data[_].Features[_]; count(rpm.Vulnerabilities) > 0; rpm.Vulnerabilities[_].Severity == "Low"}
   not count(rpms_with_low_vulnerabilities) == 0
 
   name := "clair_low_vulnerabilities"
-  msg = sprintf("Found packages with low vulnerabilities: %s", [concat(", ", rpms_with_low_vulnerabilities)])
-  description := "The image musn't contain packages that have low severity vulnerabilities."
-  url := "https://source.redhat.com/groups/public/product-security/content/product_security_folder/understanding_red_hat_security_vulnerabilities_10pdf"
+  vulns_num = count(rpms_with_low_vulnerabilities)
+  msg := "Found packages with low vulnerabilities. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
+  description = sprintf("Packages found: %s", [concat(", ", rpms_with_low_vulnerabilities)])
+  url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 }
-

--- a/unittests/test_clair/vulnerabilities-check_test.rego
+++ b/unittests/test_clair/vulnerabilities-check_test.rego
@@ -5,23 +5,27 @@ import data.clair as clair
 test_violation_critical_vulnerabilities {
     result := violation_critical_vulnerabilities with input as clair
     result[_].details.name == "clair_critical_vulnerabilities"
-    result[_].msg == "Found packages with critical vulnerabilities: pip"
+    result[_].vulnerabilities_number == 1
+    result[_].msg == "Found packages with critical vulnerabilities. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
 }
 
 test_violation_high_vulnerabilities {
     result := violation_high_vulnerabilities with input as clair
     result[_].details.name == "clair_high_vulnerabilities"
-    result[_].msg == "Found packages with high vulnerabilities: zlib"
+    result[_].vulnerabilities_number == 1
+    result[_].msg == "Found packages with high vulnerabilities. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
 }
 
 test_violation_medium_vulnerabilities {
     result := violation_medium_vulnerabilities with input as clair
     result[_].details.name == "clair_medium_vulnerabilities"
-    result[_].msg == "Found packages with medium vulnerabilities: pip"
+    result[_].vulnerabilities_number == 2
+    result[_].msg == "Found packages with medium vulnerabilities. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
 }
 
 test_violation_low_vulnerabilities {
     result := violation_low_vulnerabilities with input as clair
     result[_].details.name == "clair_low_vulnerabilities"
-    result[_].msg == "Found packages with low vulnerabilities: pip"
+    result[_].vulnerabilities_number == 1
+    result[_].msg == "Found packages with low vulnerabilities. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
 }

--- a/unittests/test_data/clair.json
+++ b/unittests/test_data/clair.json
@@ -159,7 +159,7 @@
             "Version": "1.34.1-r3",
             "Vulnerabilities": [
               {
-                "Severity": "Unknown",
+                "Severity": "Medium",
                 "NamespaceName": "alpine-main-v3.15-updater",
                 "Link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=ALPINE-13661",
                 "FixedBy": "1.34.1-r5",


### PR DESCRIPTION
example output after the change:

```
[jsztuka@fedora hacbs-test]$ conftest test --no-fail ~/Documents/playground/tkn/clair-result.json --policy policies/clair/vulnerabilities-check.rego --namespace required_checks --output=json
[
        {
                "filename": "/home/jsztuka/Documents/playground/tkn/clair-result.json",
                "namespace": "required_checks",
                "successes": 1,
                "failures": [
                        {
                                "msg": "Found packages with high vulnerabilities. Consider updating to newer version of those packages, they may not longet be affected by the reported CVEs. You can check clair logs for more infromation. Packages found: expat, krb5-libs, libksba, python39, python39-libs, systemd, systemd-libs, systemd-pam, urllib3, wheel, xz-libs",
                                "metadata": {
                                        "details": {
                                                "description": "The image shouldn't contain packages that have high severity vulnerabilities.",
                                                "name": "clair_high_vulnerabilities"
                                        },
                                        "vulnerabilities-count": 11
                                }
                        },
                        {
                                "msg": "Found packages with medium vulnerabilities. Consider updating to newer version of those packages, they may not longet be affected by the reported CVEs. You can check clair logs for more infromation. Packages found: containers-common, criu, curl, dbus, dbus-common, dbus-daemon, dbus-libs, dbus-tools, expat, fuse-overlayfs, gnupg2, gnutls, libcom_err, libcurl, libgcrypt, libslirp, libtasn1, libxml2, openssl-libs, pcre2, platform-python, platform-python-setuptools, python3-libs, python3-libxml2, python3-setuptools-wheel, python39, python39-libs, runc, setuptools, skopeo, slirp4netns, sqlite-libs, systemd, systemd-libs, systemd-pam, tar, vim-minimal, zlib",
                                "metadata": {
                                        "details": {
                                                "description": "The image shouldn't contain packages that have medium severity vulnerabilities.",
                                                "name": "clair_medium_vulnerabilities"
                                        },
                                        "vulnerabilities-count": 38
                                }
                        },
                        {
                                "msg": "Found packages with low vulnerabilities. Consider updating to newer version of those packages, they may not longet be affected by the reported CVEs. You can check clair logs for more infromation. Packages found: containers-common, criu, fuse-overlayfs, libslirp, runc, skopeo, slirp4netns",
                                "metadata": {
                                        "details": {
                                                "description": "The image shouldn't contain packages that have low severity vulnerabilities.",
                                                "name": "clair_low_vulnerabilities"
                                        },
                                        "vulnerabilities-count": 7
                                }
                        }
                ]
        }
]
```