### PR TITLE
fix(utils): remove hacbs prefix from result

### DIFF
--- a/test/selftest.sh
+++ b/test/selftest.sh
@@ -34,9 +34,9 @@ check_return_code
 echo "Testing shell function parse_hacbs_test_output"
 . /utils.sh
 conftest test --namespace optional_checks --policy $POLICY_PATH/image/inherited-labels.rego label.json --output=json > unittest.json
-HACBS_TEST_OUTPUT=
+TEST_OUTPUT=
 parse_hacbs_test_output sanity_label_check conftest unittest.json
-[ "$(echo $HACBS_TEST_OUTPUT | jq -r '.result')" == "SUCCESS" ] && echo "test_parse_hacbs_test_output PASSED" || exit 1
+[ "$(echo $TEST_OUTPUT | jq -r '.result')" == "SUCCESS" ] && echo "test_parse_hacbs_test_output PASSED" || exit 1
 
 echo "Starting Integeration-Tests"
 bats $POLICY_PATH/conftest.sh

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 
-# returns HACBS_TEST_OUTPUT json with predefined default. Function accepts optional args to modify result
+# returns TEST_OUTPUT json with predefined default. Function accepts optional args to modify result
 # see make_result_json_usage for usage
 make_result_json() {
   local RESULT=""
@@ -83,7 +83,7 @@ make_result_json() {
 }
 
 
-# Parse test result and genarate HACBS_TEST_OUTPUT
+# Parse test result and genarate TEST_OUTPUT
 parse_hacbs_test_output() {
   # The name of test
   TEST_NAME=$1
@@ -112,13 +112,13 @@ parse_hacbs_test_output() {
 
   # Handle the test result with format of sarif
   if [ "$TEST_RESULT_FORMAT" = "sarif" ]; then
-    HACBS_TEST_OUTPUT=$(make_result_json \
+    TEST_OUTPUT=$(make_result_json \
       -r "$(jq -rce '(if (.runs[].results | length > 0) then "FAILURE" else "SUCCESS" end)' "${TEST_RESULT_FILE}" || echo 'ERROR')" \
       -f "$(jq -rce '(.runs[].results | length)' "${TEST_RESULT_FILE}")" \
     )
 
     # Log out the failing runs
-    if [ "$(echo "$HACBS_TEST_OUTPUT" | jq '.failures')" -gt 0 ]
+    if [ "$(echo "$TEST_OUTPUT" | jq '.failures')" -gt 0 ]
     then
       echo "Task $TEST_NAME failed because of the following issues:"
       jq '.runs[].results // []|map(.message.text) | unique' "$TEST_RESULT_FILE"
@@ -134,7 +134,7 @@ parse_hacbs_test_output() {
       exit 1
     fi
 
-    HACBS_TEST_OUTPUT=$(make_result_json \
+    TEST_OUTPUT=$(make_result_json \
       -r "$(jq -rce '.[] | (if (.failures | length > 0) then "FAILURE" else "SUCCESS" end)' "${TEST_RESULT_FILE}" || echo 'ERROR')" \
       -n "$(jq -rce '.[] | .namespace' "${TEST_RESULT_FILE}")" \
       -s "$(jq -rce '.[] | .successes' "${TEST_RESULT_FILE}")" \
@@ -142,7 +142,7 @@ parse_hacbs_test_output() {
     )
 
     # Log out the failing runs
-    if [ "$(echo "$HACBS_TEST_OUTPUT" | jq '.failures')" -gt 0 ]
+    if [ "$(echo "$TEST_OUTPUT" | jq '.failures')" -gt 0 ]
     then
       echo "Task $TEST_NAME failed because of the following issues:"
       jq '.[].failures // []|map(.metadata.details.name) | unique' "$TEST_RESULT_FILE"

--- a/unittests_bash/test_utils.bats
+++ b/unittests_bash/test_utils.bats
@@ -64,17 +64,17 @@ setup() {
 }
 
 @test "Conftest input: successful tests" {
-    HACBS_TEST_OUTPUT=""
+    TEST_OUTPUT=""
     parse_hacbs_test_output testname conftest unittests_bash/data/conftest_successes.json
     EXPECTED_JSON='{"result":"SUCCESS","timestamp":"whatever","note":"For details, check Tekton task log.","namespace":"image_labels","successes":19,"failures":0,"warnings":0}'
-    test_json_eq "${EXPECTED_JSON}" "${HACBS_TEST_OUTPUT}"
+    test_json_eq "${EXPECTED_JSON}" "${TEST_OUTPUT}"
 }
 
 @test "Conftest input: failed tests" {
-    HACBS_TEST_OUTPUT=""
+    TEST_OUTPUT=""
     parse_hacbs_test_output testname conftest unittests_bash/data/conftest_failures.json
     EXPECTED_JSON='{"result":"FAILURE","timestamp":"whatever","note":"For details, check Tekton task log.","namespace":"image_labels","successes":19,"failures":1,"warnings":0}'
-    test_json_eq "${EXPECTED_JSON}" "${HACBS_TEST_OUTPUT}"
+    test_json_eq "${EXPECTED_JSON}" "${TEST_OUTPUT}"
 }
 
 @test "Conftest input: more than 1 result" {
@@ -84,15 +84,15 @@ setup() {
 }
 
 @test "Sarif input: successful tests" {
-    HACBS_TEST_OUTPUT=""
+    TEST_OUTPUT=""
     parse_hacbs_test_output testname sarif unittests_bash/data/sarif_successes.json
     EXPECTED_JSON='{"result":"SUCCESS","timestamp":"whatever","note":"For details, check Tekton task log.","namespace":"default","successes":0,"failures":0,"warnings":0}'
-    test_json_eq "${EXPECTED_JSON}" "${HACBS_TEST_OUTPUT}"
+    test_json_eq "${EXPECTED_JSON}" "${TEST_OUTPUT}"
 }
 
 @test "Sarif input: failed tests" {
-    HACBS_TEST_OUTPUT=""
+    TEST_OUTPUT=""
     parse_hacbs_test_output testname sarif unittests_bash/data/sarif_failures.json
     EXPECTED_JSON='{"result":"FAILURE","timestamp":"whatever","note":"For details, check Tekton task log.","namespace":"default","successes":0,"failures":1,"warnings":0}'
-    test_json_eq "${EXPECTED_JSON}" "${HACBS_TEST_OUTPUT}"
+    test_json_eq "${EXPECTED_JSON}" "${TEST_OUTPUT}"
 }


### PR DESCRIPTION
This PR will unblock failures such:
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/redhat-appstudio_build-service/149/pull-ci-redhat-appstudio-build-service-main-build-service-e2e/1653317992936640512

Function to parse output name will be changed in another PR since it would mean to also change build-def side at this moment and also more time to changes to take place.