### PR TITLE
fix(STONEINTG-361): policy unit tests doesn't emit failure

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -84,8 +84,18 @@ jobs:
 
       - name: Run unittests for policies
         run: |
-         TEST_FILES="./policies ./unittests ./unittests/test_data"
-         /usr/bin/opa test --coverage --format json $TEST_FILES | { T=`mktemp`; tee $T; /usr/bin/opa eval --format pretty --input $T --data hack/simplecov.rego data.simplecov.from_opa > coverage.json; rm -f $T || true; } | jq -j -r 'if .coverage < 100 then "ERROR: Code coverage threshold not met: got \(.coverage) instead of 100.00\n" | halt_error(1) else "" end'
+          set -o pipefail
+          TEST_FILES="./policies ./unittests ./unittests/test_data"
+          /usr/bin/opa test --coverage --format json $TEST_FILES \
+            | { T=`mktemp`; \
+              tee $T; \
+             /usr/bin/opa eval \
+              --format pretty \
+              --input $T \
+              --data hack/simplecov.rego \
+              data.simplecov.from_opa > coverage.json; \
+            rm -f $T || true; } \
+          | jq -j -r 'if .coverage < 100 then "ERROR: Code coverage threshold not met: got \(.coverage) instead of 100.00\n" | halt_error(1) else "" end'
 
       - name: Upload test coverage report
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
Add `pipefail` option to our shell in policy unit test step to ensure proper failure handling by GitHub Action workflow.