### PR TITLE
fix(STONEINTG-375): reporting of clair CVEs

### DIFF
--- a/policies/clair/vulnerabilities-check.rego
+++ b/policies/clair/vulnerabilities-check.rego
@@ -1,45 +1,66 @@
 package required_checks
 
+# function to get mapping {rpm: set of vulnerabilities names}; duplicated vulnerabilities are removed
+get_vulnerabilities(input_data, severity) := vulnerabilities {
+  vulnerabilities := [{"name": rpm.Name, "version": rpm.Version, "vulnerabilities": vuln} |
+    rpm := input_data.data[_].Features[_]
+    vuln := {v.Name | v:=rpm.Vulnerabilities[_]; v.Severity == severity}
+    count(vuln) > 0
+  ]
+}
+
+# function returns count of all vulnerabilities
+count_vulnerabilities(vulnerabilities) := cnt {
+  cnt := sum([count(v.vulnerabilities) | v:=vulnerabilities[_]])
+}
+
+# function generates description with RPMs and their vulnerabilities
+generate_description(vulnerabilities) := dsc {
+  dsc := sprintf("Vulnerabilities found: %s", [concat(", ",
+                   [sprintf("%s-%s (%s)", [v.name, v.version, concat(", ", v.vulnerabilities)]) | v := vulnerabilities[_]]
+                 )])
+}
+
 violation_critical_vulnerabilities[{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] {
-  rpms_with_critical_vulnerabilities := {rpm.Name | rpm := input.data[_].Features[_]; count(rpm.Vulnerabilities) > 0; rpm.Vulnerabilities[_].Severity == "Critical"}
+  rpms_with_critical_vulnerabilities := get_vulnerabilities(input, "Critical")
   not count(rpms_with_critical_vulnerabilities) == 0
 
   name := "clair_critical_vulnerabilities"
-  vulns_num = count(rpms_with_critical_vulnerabilities)
+  vulns_num := count_vulnerabilities(rpms_with_critical_vulnerabilities)
   msg := "Found packages with critical vulnerabilities. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
-  description = sprintf("Packages found: %s", [concat(", ", rpms_with_critical_vulnerabilities)])
+  description := generate_description(rpms_with_critical_vulnerabilities)
   url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 }
 
 violation_high_vulnerabilities[{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] {
-  rpms_with_high_vulnerabilities := {rpm.Name | rpm := input.data[_].Features[_]; count(rpm.Vulnerabilities) > 0; rpm.Vulnerabilities[_].Severity == "High"}
+  rpms_with_high_vulnerabilities := get_vulnerabilities(input, "High")
   not count(rpms_with_high_vulnerabilities) == 0
 
   name := "clair_high_vulnerabilities"
-  vulns_num = count(rpms_with_high_vulnerabilities)
+  vulns_num = count_vulnerabilities(rpms_with_high_vulnerabilities)
   msg := "Found packages with high vulnerabilities. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
-  description = sprintf("Packages found: %s", [concat(", ", rpms_with_high_vulnerabilities)])
+  description := generate_description(rpms_with_high_vulnerabilities)
   url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 }
 
 violation_medium_vulnerabilities[{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] {
-  rpms_with_medium_vulnerabilities := {rpm.Name | rpm := input.data[_].Features[_]; count(rpm.Vulnerabilities) > 0; rpm.Vulnerabilities[_].Severity == "Medium"}
+  rpms_with_medium_vulnerabilities := get_vulnerabilities(input, "Medium")
   not count(rpms_with_medium_vulnerabilities) == 0
 
   name := "clair_medium_vulnerabilities"
-  vulns_num = count(rpms_with_medium_vulnerabilities)
+  vulns_num := count_vulnerabilities(rpms_with_medium_vulnerabilities)
   msg := "Found packages with medium vulnerabilities. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
-  description = sprintf("Packages found: %s", [concat(", ", rpms_with_medium_vulnerabilities)])
+  description := generate_description(rpms_with_medium_vulnerabilities)
   url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 }
 
 violation_low_vulnerabilities[{"msg": msg, "vulnerabilities_number": vulns_num, "details":{"name": name, "description": description, "url": url}}] {
-  rpms_with_low_vulnerabilities := {rpm.Name | rpm := input.data[_].Features[_]; count(rpm.Vulnerabilities) > 0; rpm.Vulnerabilities[_].Severity == "Low"}
+  rpms_with_low_vulnerabilities := get_vulnerabilities(input, "Low")
   not count(rpms_with_low_vulnerabilities) == 0
 
   name := "clair_low_vulnerabilities"
-  vulns_num = count(rpms_with_low_vulnerabilities)
+  vulns_num := count_vulnerabilities(rpms_with_low_vulnerabilities)
   msg := "Found packages with low vulnerabilities. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
-  description = sprintf("Packages found: %s", [concat(", ", rpms_with_low_vulnerabilities)])
+  description := generate_description(rpms_with_low_vulnerabilities)
   url := "https://access.redhat.com/articles/red_hat_vulnerability_tutorial"
 }

--- a/unittests/test_clair/vulnerabilities-check_test.rego
+++ b/unittests/test_clair/vulnerabilities-check_test.rego
@@ -12,14 +12,14 @@ test_violation_critical_vulnerabilities {
 test_violation_high_vulnerabilities {
     result := violation_high_vulnerabilities with input as clair
     result[_].details.name == "clair_high_vulnerabilities"
-    result[_].vulnerabilities_number == 1
+    result[_].vulnerabilities_number == 2
     result[_].msg == "Found packages with high vulnerabilities. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
 }
 
 test_violation_medium_vulnerabilities {
     result := violation_medium_vulnerabilities with input as clair
     result[_].details.name == "clair_medium_vulnerabilities"
-    result[_].vulnerabilities_number == 2
+    result[_].vulnerabilities_number == 3
     result[_].msg == "Found packages with medium vulnerabilities. Consider updating to a newer version of those packages, they may no longer be affected by the reported CVEs."
 }
 

--- a/unittests/test_data/clair.json
+++ b/unittests/test_data/clair.json
@@ -112,8 +112,8 @@
                 "NamespaceName": "pyupio",
                 "Link": "",
                 "FixedBy": "",
-                "Description": "The urllib3 library 1.26.x before 1.26.4 for Python omits SSL certificate validation in some cases involving HTTPS to HTTPS proxies. The initial connection to the HTTPS proxy (if an SSLContext isn't given via proxy_config) doesn't verify the hostname of the certificate. This means certificates for different servers that still validate properly with the default urllib3 SSLContext will be silently accepted.",
-                "Name": "pyup.io-40291 (CVE-2021-28363)",
+                "Description": "another medium level CVE, to test if multiple CVEs per RPM are reported correctly",
+                "Name": "pyup.io-40291 (CVE-another-cve-for-the-test)",
                 "Metadata": {
                   "UpdatedBy": "pyupio",
                   "RepoName": "pypi",
@@ -129,11 +129,11 @@
                 }
               },
               {
-                "Severity": "Medium",
+                "Severity": "Critical",
                 "NamespaceName": "pyupio",
                 "Link": "",
                 "FixedBy": "",
-                "Description": "Pip 21.1 updates its dependency 'urllib3' to v1.26.4 due to security issues.",
+                "Description": "Pip 21.1 updates its dependency 'urllib3' to v1.26.4 due to security issues. (TEST that the same CVE is not reportted twice)",
                 "Name": "pyup.io-40291 (CVE-2021-28363)",
                 "Metadata": {
                   "UpdatedBy": "pyupio",
@@ -194,6 +194,36 @@
                 "Link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-25032",
                 "FixedBy": "1.2.12-r0",
                 "Description": "",
+                "Name": "CVE-2018-25032",
+                "Metadata": {
+                  "UpdatedBy": "alpine-main-v3.15-updater",
+                  "RepoName": null,
+                  "RepoLink": null,
+                  "DistroName": "Alpine Linux",
+                  "DistroVersion": "",
+                  "NVD": {
+                    "CVSSv3": {
+                      "Vectors": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                      "Score": 7.5
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "Name": "zlib",
+            "VersionFormat": "",
+            "NamespaceName": "",
+            "AddedBy": "sha256:59bf1c3509f33515622619af21ed55bbe26d24913cedbca106468a5fb37a50c3",
+            "Version": "1.2.11-r3-different",
+            "Vulnerabilities": [
+              {
+                "Severity": "High",
+                "NamespaceName": "alpine-main-v3.15-updater",
+                "Link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-25032",
+                "FixedBy": "1.2.12-r0",
+                "Description": "TEST: The same vulnerability, but different version of package",
                 "Name": "CVE-2018-25032",
                 "Metadata": {
                   "UpdatedBy": "alpine-main-v3.15-updater",


### PR DESCRIPTION
Clair rego policy will work now with pairs RPM and their vulnerabilities on the particular severity level. Insted of counting number of affected RPMs, it will report number of vulnerabilities (i.e. more than RPMs if single RPM has more vulnerabilities).

This behavior is more aligned with quay.io reporting

Adressing issues:
* Clair provides "duplicated" CVEs when violation comes from multiple repo sources, only unique CVE is counted.
* Number of unique CVEs per RPM is counted instead of plain number of affected RPMs; aggregated as sum of all vulnerabilites per RPM on the same severity level
* Description also contains list of CVE names affecting RPM