### PR TITLE
chore(gitlint): test only pullrequests

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -133,6 +133,7 @@ jobs:
           ignore_paths: './test/conftest.sh ./test/selftest.sh'  # for now
   gitlint:
     name: Run gitlint checks
+    if: ${{ github.event_name == 'pull_request' }}  # we can test only PRs
     runs-on: ubuntu-20.04
     steps:
       - name: Check out code


### PR DESCRIPTION
We can test only pullrequests with current implementation. For push events we would need to use diffrent variables (`github.event.push.*`)

So far testing only PR is good and we don't need more complicated implementations