### PR TITLE
fix(pr-checks): Build the hacbs-test image in GH actions with podman

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -54,16 +54,11 @@ jobs:
 
       - name: Install packages
         run: |
-          dnf install -y podman buildah
+          dnf install -y podman
 
       - name: Build image
-        uses: redhat-actions/buildah-build@v2
-        with:
-          image: hacbs-test
-          tags: ${{ github.sha }}
-          arch: amd64
-          containerfiles: |
-            ./Dockerfile
+        run: |
+          podman build -t hacbs-test:${{ github.sha }} .
 
       - name: Selfcheck - Integration test inside the image
         run: |


### PR DESCRIPTION
Resolves issue of buildah breaking podman if the Containerfile has any `run` commands.