### PR TITLE
fix(test): integration test fails on false negative for clair

### DIFF
--- a/test/conftest.sh
+++ b/test/conftest.sh
@@ -30,7 +30,7 @@
 # CLAIR for test_clair
 @test "/project/clair/vulnerabilities-check" {
   run conftest test --namespace required_checks --policy $POLICY_PATH/clair/vulnerabilities-check.rego clair.json
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 0 ]
 }
 
 # REPOSITORY for test_repo


### PR DESCRIPTION
STONEINTG-360 modified Clair rego policy to return warnings as opposed to violations. This caused integration tests to fail when expecting a failed status return.