### PR TITLE
feat(STONEINTG-429): pin conftest image & update opa version

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Install dependency packages
         run: |
          sudo apt-get install jq
-         sudo curl -L -o /usr/bin/opa https://openpolicyagent.org/downloads/v0.48.0/opa_linux_amd64_static
+         sudo curl -L -o /usr/bin/opa https://openpolicyagent.org/downloads/v0.54.0/opa_linux_amd64_static
          sudo chmod 755 /usr/bin/opa
 
       - name: Run unittests for policies


### PR DESCRIPTION
Update the opa package and modify dockerfile to allow dependabot to monitor conftest going forward. Note, dependabot is NOT watching opa versioning.