### PR TITLE
feat(STONE-254): use ubi-minimal as base img

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM docker.io/snyk/snyk:linux@sha256:606839193a672e026e832faac45d218f7ed55406d8
 # To find the OPA version associated with conftest run the following:
 # podman run --rm -ti ${NEW_IMAGE}  --version
 FROM docker.io/openpolicyagent/conftest:v0.44.1@sha256:93c0fccb97538b24ecb8492c5c988f39d27ec7108d4ce99f217677ad50f4271e as conftest
-FROM registry.access.redhat.com/ubi8/ubi:8.8-1032.1692772289
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
+
 
 ARG BATS_VERSION=1.6.0
 ARG cyclonedx_version=0.24.2
@@ -13,33 +14,33 @@ ARG OPM_VERSION=v1.26.3
 
 ENV POLICY_PATH="/project"
 
-RUN ARCH=$(uname -m) && curl https://mirror.openshift.com/pub/openshift-v4/"$ARCH"/clients/ocp/stable/openshift-client-linux.tar.gz --output oc.tar.gz && tar -xzvf oc.tar.gz -C /usr/bin && rm oc.tar.gz && \
-    curl -LO "https://github.com/bats-core/bats-core/archive/refs/tags/v$BATS_VERSION.tar.gz" && \
-    curl -L https://github.com/operator-framework/operator-registry/releases/download/"${OPM_VERSION}"/linux-amd64-opm > /usr/bin/opm && chmod +x /usr/bin/opm && \ 
-    curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py" && \
-    tar -xf "v$BATS_VERSION.tar.gz" && \
-    cd "bats-core-$BATS_VERSION" && \
-    ./install.sh /usr && \
-    cd .. && rm -rf "bats-core-$BATS_VERSION" && rm -rf "v$BATS_VERSION.tar.gz" && \
-    dnf -y --setopt=tsflags=nodocs install \
+RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
+    microdnf -y --setopt=tsflags=nodocs --setopt=install_weak_deps=0 install \
     jq \
     skopeo \
+    tar \
     python39 \
-    https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
-    dnf -y --setopt=tsflags=nodocs install \
     clamav \
     clamd \
+    python39-pip \
     clamav-update && \
-    cd / && \
-    python3.9 get-pip.py && \
-    pip install --no-cache-dir python-dateutil yq && \
+    pip3 install --no-cache-dir python-dateutil yq && \
     curl -L https://github.com/CycloneDX/sbom-utility/releases/download/v"${sbom_utility_version}"/sbom-utility-v"${sbom_utility_version}"-linux-amd64.tar.gz --output sbom-utility.tar.gz && \
     mkdir sbom-utility && tar -xf sbom-utility.tar.gz -C sbom-utility && rm sbom-utility.tar.gz && \
     cd /usr/bin && \
     curl -OL https://github.com/CycloneDX/cyclonedx-cli/releases/download/v"${cyclonedx_version}"/cyclonedx-linux-x64 && \
-    dnf -y install libicu && \
+    microdnf -y install libicu && \
     chmod +x cyclonedx-linux-x64 && \
-    dnf clean all
+    microdnf clean all
+
+RUN ARCH=$(uname -m) && curl https://mirror.openshift.com/pub/openshift-v4/"$ARCH"/clients/ocp/stable/openshift-client-linux.tar.gz --output oc.tar.gz && tar -xzvf oc.tar.gz -C /usr/bin && rm oc.tar.gz && \
+    curl -LO "https://github.com/bats-core/bats-core/archive/refs/tags/v$BATS_VERSION.tar.gz" && \
+    curl -L https://github.com/operator-framework/operator-registry/releases/download/"${OPM_VERSION}"/linux-amd64-opm > /usr/bin/opm && chmod +x /usr/bin/opm && \ 
+    tar -xf "v$BATS_VERSION.tar.gz" && \
+    cd "bats-core-$BATS_VERSION" && \
+    ./install.sh /usr && \
+    cd .. && rm -rf "bats-core-$BATS_VERSION" && rm -rf "v$BATS_VERSION.tar.gz" && \
+    cd /
 
 ENV PATH="${PATH}:/sbom-utility"
 

--- a/clamav/Dockerfile
+++ b/clamav/Dockerfile
@@ -1,9 +1,8 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.8-1032
-RUN dnf -y --setopt=tsflags=nodocs install \
-    https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
-    dnf -y --setopt=tsflags=nodocs install \
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
+RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
+    microdnf -y --setopt=tsflags=nodocs install \
     clamav \
     clamd \
     clamav-update && \
-    dnf clean all
+    microdnf clean all
 RUN freshclam


### PR DESCRIPTION
Changing base image from ubi > ubi minimal.

Old ClamavDB image: 463 MB
New ClamavDB image:  381 MB

Old habcs-test image: 749 MB
New hacbs-test image: 669 MB

Clair in action image has already ubi-minimal as a base image, so no changes are required there.