### PR TITLE
fix(STONEINTG-222): fix pr 137

### DIFF
--- a/test/utils.sh
+++ b/test/utils.sh
@@ -157,18 +157,24 @@ parse_test_output() {
   fi
 }
 
-# the function will be used by the tekton tasks of build-definitions
+# The function will be used by the tekton tasks of build-definitions
+# It need tekton result path as parameter
 handle_error()
 {
-  # The tekton task result path
-  TEST_RESULT_PATH=$1
-  if [ -z "$TEST_RESULT_PATH" ]; then
-    echo "Missing parameter TEST_RESULT_PATH" >&2
-    exit 2
-  fi
+  exit_code=$?
+  if [ "${exit_code}" -ne 0 ]; then
+    # The tekton task result path
+    TEST_OUTPUT_PATH=$1
+    if [ -z "$TEST_OUTPUT_PATH" ]; then
+      echo "Missing parameter TEST_OUTPUT_PATH" >&2
+      exit 2
+    fi
 
-  note="Unexpected error: Script errored at line ${LINENO}: ${BASH_COMMAND}."
-  ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
-  echo "${ERROR_OUTPUT}" | tee "$(TEST_RESULT_PATH)"
-  exit 0
+    note="Unexpected error: Script errored at command: ${BASH_COMMAND}."
+    ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+    echo "${ERROR_OUTPUT}" | tee "$TEST_OUTPUT_PATH"
+    exit 0
+  else
+    exit 0
+  fi
 }


### PR DESCRIPTION
* ERR can't handle the syntax error like undefined variable in our hasbs-test image, so use EXIT. See https://stackoverflow.com/questions/58317346/err-trap-is-not-executed-when-syntax-error

Then it can be used as below to catch nonexisting file error
```
      trap 'handle_error "TEST_OUTPUT"' EXIT

      cat nonexisting_file
```
or undefined variable
```
      trap 'handle_error "TEST_OUTPUT"' EXIT

      echo $undefined_variable
```


Signed-off-by: Hongwei Liu <hongliu@redhat.com>