### PR TITLE
chore: use OPA v0.56.0

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Install dependency packages
         run: |
          sudo apt-get install jq
-         sudo curl -L -o /usr/bin/opa https://openpolicyagent.org/downloads/v0.54.0/opa_linux_amd64_static
+         sudo curl -L -o /usr/bin/opa https://openpolicyagent.org/downloads/v0.56.0/opa_linux_amd64_static
          sudo chmod 755 /usr/bin/opa
 
       - name: Run unittests for policies


### PR DESCRIPTION
* Align OPA version in pr-checks with conftest v0.45.0
* Follow-up on #136 