### PR TITLE
fix: revert to downloading conftest binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
 # Container image that runs your code
 FROM docker.io/snyk/snyk:linux@sha256:daa381bb0dc69c75043d1c5307c9e3ae84e8413ecc3094fa25fa214a8591a8fb as snyk
-# Note that the version of OPA used by pr-checks must be updated manually to reflect dependabot updates
-# To find the OPA version associated with conftest run the following:
-# podman run --rm -ti ${NEW_IMAGE}  --version
-FROM docker.io/openpolicyagent/conftest:v0.45.0@sha256:614b456d9a301ef3d43bf4d0d3b4cb79f5cd8f7a1364780c911c2f2d2d5766ad as conftest
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1072
 
-
+# Note that the version of OPA used by pr-checks must be updated manually to reflect conftest updates
+# To find the OPA version associated with conftest run the following with the relevant version of conftest:
+# $ conftest --version
+ARG conftest_version=0.45.0
 ARG BATS_VERSION=1.6.0
 ARG cyclonedx_version=0.24.2
 ARG sbom_utility_version=0.12.0
@@ -33,9 +32,10 @@ RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.
     chmod +x cyclonedx-linux-x64 && \
     microdnf clean all
 
-RUN ARCH=$(uname -m) && curl https://mirror.openshift.com/pub/openshift-v4/"$ARCH"/clients/ocp/stable/openshift-client-linux.tar.gz --output oc.tar.gz && tar -xzvf oc.tar.gz -C /usr/bin && rm oc.tar.gz && \
+RUN ARCH=$(uname -m) && curl -L https://github.com/open-policy-agent/conftest/releases/download/v"${conftest_version}"/conftest_"${conftest_version}"_Linux_"$ARCH".tar.gz | tar -xz --no-same-owner -C /usr/bin/ && \
+    curl https://mirror.openshift.com/pub/openshift-v4/"$ARCH"/clients/ocp/stable/openshift-client-linux.tar.gz --output oc.tar.gz && tar -xzvf oc.tar.gz -C /usr/bin && rm oc.tar.gz && \
     curl -LO "https://github.com/bats-core/bats-core/archive/refs/tags/v$BATS_VERSION.tar.gz" && \
-    curl -L https://github.com/operator-framework/operator-registry/releases/download/"${OPM_VERSION}"/linux-amd64-opm > /usr/bin/opm && chmod +x /usr/bin/opm && \ 
+    curl -L https://github.com/operator-framework/operator-registry/releases/download/"${OPM_VERSION}"/linux-amd64-opm > /usr/bin/opm && chmod +x /usr/bin/opm && \
     tar -xf "v$BATS_VERSION.tar.gz" && \
     cd "bats-core-$BATS_VERSION" && \
     ./install.sh /usr && \
@@ -45,8 +45,6 @@ RUN ARCH=$(uname -m) && curl https://mirror.openshift.com/pub/openshift-v4/"$ARC
 ENV PATH="${PATH}:/sbom-utility"
 
 COPY --from=snyk /usr/local/bin/snyk /usr/local/bin/snyk
-COPY --from=conftest /usr/local/bin/conftest /usr/local/bin/conftest
-
 
 COPY policies $POLICY_PATH
 COPY test/conftest.sh $POLICY_PATH


### PR DESCRIPTION
* The conftest images in dockerhub don't have a ppc64le version, causing failures when releasing the image
* This change reverts to downloading the binary from gitHub, with the comment to also update the pr-checks OPA version