### PR TITLE
fix(STONEINTG-634): don't set -euo pipefail in shared lib

### DIFF
--- a/test/utils.sh
+++ b/test/utils.sh
@@ -5,8 +5,6 @@
 
 # returns TEST_OUTPUT json with predefined default. Function accepts optional args to modify result
 # see make_result_json_usage for usage
-set -euo pipefail
-
 make_result_json() {
   local RESULT=""
   local SUCCESSES=0


### PR DESCRIPTION
This unintentionally enables strict mode in all tasks which aren't ready for it