### PR TITLE
fix(STONEINTG-663): update URL and description for deprecated images

### DIFF
--- a/policies/repository/deprecated-image.rego
+++ b/policies/repository/deprecated-image.rego
@@ -4,7 +4,7 @@ violation_image_repository_deprecated[{"msg": msg, "details":{"name": name, "des
   input.release_categories[_] == "Deprecated"
 
   name := "image_repository_deprecated"
-  msg := "The container image shouldn't be built from a repository that is marked as 'Deprecated' in COMET."
+  msg := "The container image shouldn't be built from a repository that is marked as 'Deprecated' in Red Hat Catalog."
   description := "Deprecated images are no longer maintained and will accumulate security vulnerabilities without releasing a fixed version."
-  url := "https://source.redhat.com/groups/public/portfolio-programs-group/container_factory_blog/dont_build_on_deprecated_images"
+  url := "https://redhat-connect.gitbook.io/catalog-help/container-images/container-image-details/container-image-release-categories"
 }

--- a/unittests/test_repository/deprecated-image_test.rego
+++ b/unittests/test_repository/deprecated-image_test.rego
@@ -5,5 +5,6 @@ import data.repository as repository
 test_violation_image_repository_deprecated {
     result := violation_image_repository_deprecated with input as repository
     result[_].details.name == "image_repository_deprecated"
-    result[_].msg == "The container image shouldn't be built from a repository that is marked as 'Deprecated' in COMET."
+    result[_].msg == "The container image shouldn't be built from a repository that is marked as 'Deprecated' in Red Hat Catalog."
+    result[_].details.url == "https://redhat-connect.gitbook.io/catalog-help/container-images/container-image-details/container-image-release-categories"
 }


### PR DESCRIPTION
* Use the Container image release categories article which holds a concise and long-lived definition for 'deprecated' as well as being publicly available
* Replace reference to COMET with Red Hat Catalog