### PR TITLE
fix(STONEINTG-624): align PR and release workflow

### DIFF
--- a/.github/workflows/build_reusable.yaml
+++ b/.github/workflows/build_reusable.yaml
@@ -1,0 +1,66 @@
+on:
+  workflow_call:
+    inputs:
+      archs:
+        description: "Build image for defined architectures. Must be comma-separated list of architectures."
+        required: false
+        default: "amd64,ppc64le"
+        type: string
+      tags:
+        description: "Tags to be used for the image. Must be space separated list of tags."
+        required: true
+        type: string
+      push:
+        description: "Determine if image should be pushed into registry. By default image will be only built and tested locally."
+        required: false
+        type: boolean
+        default: false
+jobs:
+  build_container_image:
+    name: Build and check main image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Docker file code in the root directory
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static podman
+
+      - name: Build Image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: hacbs-test
+          tags: ${{ inputs.tags }}
+          archs: ${{ inputs.archs }}
+          containerfiles: |
+            ./Dockerfile
+
+      - name: Selfcheck - Integration test inside the image
+        run: |
+          archs="${{ inputs.archs }}"
+          for i in ${archs//,/$IFS}
+          do
+            echo "START of testing architecture ${arch}"
+            podman run --arch "${arch}" --rm -t ${{ steps.build-image.outputs.image-with-tag }} /selftest.sh
+            echo "END of testing for architecture ${arch}"
+            echo
+          done
+
+      - name: Push To quay.io
+        id: push-to-quay
+        if: ${{ inputs.push }}
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: quay.io/redhat-appstudio
+          username: ${{ secrets.HACBS_TEST_QUAY_USER }}
+          password: ${{ secrets.HACBS_TEST_QUAY_TOKEN }}
+
+      - name: Print image url
+        if: ${{ inputs.push }}
+        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -39,30 +39,12 @@ jobs:
           dockerfile: Dockerfile
           ignore: DL3003,DL3013,DL3041,DL4006  # DL4006 seems broken
 
-  container_image_main:
-    name: Check main image build
-    runs-on: ubuntu-latest
-    container:
-      image: registry.fedoraproject.org/fedora:37
-      options: --privileged
-
-    steps:
-      - name: Check out Docker file code in the root directory
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Install packages
-        run: |
-          dnf install -y podman
-
-      - name: Build image
-        run: |
-          podman build -t hacbs-test:${{ github.sha }} .
-
-      - name: Selfcheck - Integration test inside the image
-        run: |
-          podman run --rm -t hacbs-test:${{ github.sha }} /selftest.sh
+  call-build-and-test-workflow:
+    name: Call build and test workflow
+    uses: ./.github/workflows/build_reusable.yaml
+    with:
+      tags: ${{ github.sha }}
+    secrets: inherit
 
   opa_policies_unittest:
     name: opa_policies_unittest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,41 +11,21 @@ on:
         default: 'main'
 
 jobs:
-  build:
+  call-build-test-and-push-workflow:
+    name: Call build, test and push workflow
+    uses: ./.github/workflows/build_reusable.yaml
+    with:
+      tags: latest v${{ github.event.inputs.release-version }} ${{ github.sha }}
+      push: true
+    secrets: inherit
+
+  github-release:
     name: Build and push image
     runs-on: ubuntu-20.04
-
+    needs:
+      - call-build-test-and-push-workflow
     steps:
     - uses: actions/checkout@v4
-
-    - name: Install qemu dependency
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y qemu-user-static
-
-    - name: Build Image
-      id: build-image
-      uses: redhat-actions/buildah-build@v2
-      with:
-        image: hacbs-test
-        tags: latest v${{ github.event.inputs.release-version }} ${{ github.sha }}
-        archs: amd64,ppc64le
-        containerfiles: |
-          ./Dockerfile
-    # Podman Login action (https://github.com/redhat-actions/podman-login) also be used to log in,
-    # in which case 'username' and 'password' can be omitted.
-    - name: Push To quay.io
-      id: push-to-quay
-      uses: redhat-actions/push-to-registry@v2
-      with:
-        image: ${{ steps.build-image.outputs.image }}
-        tags: ${{ steps.build-image.outputs.tags }}
-        registry: quay.io/redhat-appstudio
-        username: ${{ secrets.HACBS_TEST_QUAY_USER }}
-        password: ${{ secrets.HACBS_TEST_QUAY_TOKEN }}
-
-    - name: Print image url
-      run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
 
     - name: Bump version and push tag
       id: tag_version

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,18 +25,18 @@ RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.
     python39-pip \
     clamav-update && \
     pip3 install --no-cache-dir python-dateutil yq && \
-    curl -L https://github.com/CycloneDX/sbom-utility/releases/download/v"${sbom_utility_version}"/sbom-utility-v"${sbom_utility_version}"-linux-amd64.tar.gz --output sbom-utility.tar.gz && \
+    curl -s -L https://github.com/CycloneDX/sbom-utility/releases/download/v"${sbom_utility_version}"/sbom-utility-v"${sbom_utility_version}"-linux-amd64.tar.gz --output sbom-utility.tar.gz && \
     mkdir sbom-utility && tar -xf sbom-utility.tar.gz -C sbom-utility && rm sbom-utility.tar.gz && \
     cd /usr/bin && \
-    curl -OL https://github.com/CycloneDX/cyclonedx-cli/releases/download/v"${cyclonedx_version}"/cyclonedx-linux-x64 && \
+    curl -s -OL https://github.com/CycloneDX/cyclonedx-cli/releases/download/v"${cyclonedx_version}"/cyclonedx-linux-x64 && \
     microdnf -y install libicu && \
     chmod +x cyclonedx-linux-x64 && \
     microdnf clean all
 
-RUN ARCH=$(uname -m) && curl -L https://github.com/open-policy-agent/conftest/releases/download/v"${conftest_version}"/conftest_"${conftest_version}"_Linux_"$ARCH".tar.gz | tar -xz --no-same-owner -C /usr/bin/ && \
+RUN ARCH=$(uname -m) && curl -s -L https://github.com/open-policy-agent/conftest/releases/download/v"${conftest_version}"/conftest_"${conftest_version}"_Linux_"$ARCH".tar.gz | tar -xz --no-same-owner -C /usr/bin/ && \
     curl https://mirror.openshift.com/pub/openshift-v4/"$ARCH"/clients/ocp/stable/openshift-client-linux.tar.gz --output oc.tar.gz && tar -xzvf oc.tar.gz -C /usr/bin && rm oc.tar.gz && \
-    curl -LO "https://github.com/bats-core/bats-core/archive/refs/tags/v$BATS_VERSION.tar.gz" && \
-    curl -L https://github.com/operator-framework/operator-registry/releases/download/"${OPM_VERSION}"/linux-amd64-opm > /usr/bin/opm && chmod +x /usr/bin/opm && \
+    curl -s -LO "https://github.com/bats-core/bats-core/archive/refs/tags/v$BATS_VERSION.tar.gz" && \
+    curl -s -L https://github.com/operator-framework/operator-registry/releases/download/"${OPM_VERSION}"/linux-amd64-opm > /usr/bin/opm && chmod +x /usr/bin/opm && \
     tar -xf "v$BATS_VERSION.tar.gz" && \
     cd "bats-core-$BATS_VERSION" && \
     ./install.sh /usr && \

--- a/test/selftest.sh
+++ b/test/selftest.sh
@@ -14,20 +14,20 @@ check_return_code () {
 
 # Check yq presence
 yq --version
-check_return_code 
+check_return_code
 
 #Clair DATA
-curl -H "Content-type: application/json" -XGET 'https://quay.io/api/v1/repository/redhat-appstudio/sample-image/manifest/sha256:fc78d878b68b74c965bdb857fab8a87ef75bf7e411f561b3e5fee97382c785ab/security?vulnerabilities=true' > clair.json
+curl -s -H "Content-type: application/json" -XGET 'https://quay.io/api/v1/repository/redhat-appstudio/sample-image/manifest/sha256:fc78d878b68b74c965bdb857fab8a87ef75bf7e411f561b3e5fee97382c785ab/security?vulnerabilities=true' > clair.json
 
 #RPM MANIFEST
-curl -X GET 'https://catalog.redhat.com/api/containers/v1/images/id/624bfc54f5a0de7ee0c8335c/rpm-manifest?include=rpms' > rpm-manifest.json
+curl -s -X GET 'https://catalog.redhat.com/api/containers/v1/images/id/624bfc54f5a0de7ee0c8335c/rpm-manifest?include=rpms' > rpm-manifest.json
 
 # Label data from example image with valid labels
 skopeo inspect --no-tags docker://quay.io/redhat-appstudio/sample-image:test-labels-pass > label.json
 check_return_code
 
 # Deprecated Image
-curl -X 'GET' 'https://catalog.redhat.com/api/containers/v1/repositories/registry/registry.access.redhat.com/repository/rhscl%2Fnodejs-8-rhel7' -H 'accept: application/json' > image.json
+curl -s -X 'GET' 'https://catalog.redhat.com/api/containers/v1/repositories/registry/registry.access.redhat.com/repository/rhscl%2Fnodejs-8-rhel7' -H 'accept: application/json' > image.json
 
 # FBC Image label data from example fbc index image
 skopeo inspect --no-tags docker://quay.io/redhat-appstudio/sample-image:test-index-pass > fbc_label.json


### PR DESCRIPTION
Make sure that both workflows are building and testing the same architectures in the same way.

Changes:
* New nested workflow has been created, to be used in both PR and
      release workflows. It builds and tests hacbs-test image (push is
      disabled by default)
* Builds image using buildah and emulation for all specified architectures
* Tests image using podman with emulation per each architecture
