### PR TITLE
chore(dependabot): update images weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     commit-message:
       # Prefix all commit messages with "chore(Dockerfile): "
       prefix: "chore(Dockerfile): "
@@ -42,7 +42,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/clamav"
     schedule:
-      interval: daily
+      interval: weekly
     commit-message:
       prefix: "chore(Dockerfile): "
     reviewers:


### PR DESCRIPTION
We don't need daily udpates, that would trigger too many updates for nothing, as we are not releasing so often.