### PR TITLE
feat(STONEINTG-823): upgrade to ubi9 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Container image that runs your code
 FROM docker.io/snyk/snyk:linux@sha256:24adc43bcebd703b2f8f3e175fbcd595bc77c36778f24ef0c2203b04a960bc03 as snyk
 FROM quay.io/enterprise-contract/ec-cli:snapshot@sha256:1c8bb8b6359ff05a743d228d2a713655799028808932d65aaaca84d7c3535e92 AS ec-cli
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1137
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3-1552
 
 # Note that the version of OPA used by pr-checks must be updated manually to reflect conftest updates
 # To find the OPA version associated with conftest run the following with the relevant version of conftest:
@@ -13,16 +13,16 @@ ARG OPM_VERSION=v1.26.3
 
 ENV POLICY_PATH="/project"
 
-RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
+RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
     microdnf -y --setopt=tsflags=nodocs --setopt=install_weak_deps=0 install \
     findutils \
     jq \
     skopeo \
     tar \
-    python39 \
+    python3 \
     clamav \
     clamd \
-    python39-pip \
+    python3-pip \
     clamav-update && \
     pip3 install --no-cache-dir yq && \
     curl -s -L https://github.com/CycloneDX/sbom-utility/releases/download/v"${sbom_utility_version}"/sbom-utility-v"${sbom_utility_version}"-linux-amd64.tar.gz --output sbom-utility.tar.gz && \


### PR DESCRIPTION
ubi8 have old glibc and doesn't work with some rhel9 tools. Updating to rhel9 to support newer glibc