### PR TITLE
fix: Get correct digest for image manifest in get_image_manifests

### DIFF
--- a/unittests_bash/test_utils.bats
+++ b/unittests_bash/test_utils.bats
@@ -20,10 +20,10 @@ setup() {
         if [[ $1 == "inspect" && $2 == "--no-tags" && $3 == "--raw" && $4 == "docker://valid-url" ]]; then
             echo '{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:f3d43a4e4e5371c9d972fa6a17144be940ddf3a3fd9185e2a4149a4c20e51e55","size":928,"platform":{"architecture":"amd64","os":"linux"}},{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:8e8229030a72efe300422eca38af80fae9b166361ae0f3ede8fb2fdad987f38f","size":928,"platform":{"architecture":"arm64","os":"linux"}}]}'
             return 0
-        elif [[ $1 == "inspect" && $2 == "--no-tags" && $3 == "--config" && $4 == "docker://valid-image-manifest-url" ]]; then
-            echo '{"architecture": "arm64"}'
+        elif [[ $1 == "inspect" && $2 == "--no-tags" && $3 == "docker://valid-image-manifest-url" ]]; then
+            echo '{"Architecture": "arm64", "Digest": "sha256:826def60fd1aa34f5090c9db60016773d91ecc324304d0ac3b01d"}'
             return 0
-        elif [[ $1 == "inspect" && $2 == "--no-tags" && $3 == "--raw" && $4 == "docker://valid-image-manifest-url" || $1 == "inspect" && $2 == "--no-tags" && $3 == "--raw" && $4 == "docker://valid-image-manifest-invalid-url"  ]]; then
+        elif [[ $1 == "inspect" && $2 == "--no-tags" && $3 == "--raw" && $4 == "docker://valid-image-manifest-url" || $1 == "inspect" && $2 == "--no-tags" && $3 == "--raw" && $4 == "docker://invalid-image-manifest-url"  ]]; then
             echo '{"schemaVersion": 2,"mediaType": "application/vnd.oci.image.manifest.v1+json","config": {"mediaType": "application/vnd.oci.image.config.v1+json","digest": "sha256:826def60fd1aa34f5090c9db60016773d91ecc324304d0ac3b01d","size": 14208}}'
         else
             echo 'Command execution failed'
@@ -120,7 +120,7 @@ setup() {
 
 @test "Get Image Index Manifests: invalid-url" {
     run get_image_manifests -i invalid-url
-    EXPECTED_RESPONSE='The image could not be inspected'
+    EXPECTED_RESPONSE='The raw image inspect command failed'
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 1 ]]
 }
 
@@ -138,6 +138,6 @@ setup() {
 
 @test "Get Image Manifest Digest: invalid-image-manifest-url" {
     run get_image_manifests -i invalid-image-manifest-url
-    EXPECTED_RESPONSE='The image could not be inspected'
+    EXPECTED_RESPONSE='The image manifest could not be inspected'
     [[ "${EXPECTED_RESPONSE}" = "${output}" && "$status" -eq 1 ]]
 }


### PR DESCRIPTION
Previously, the get_image_manifests was getting the `digest` for the image manifest using `skopeo inspect --raw | jq .config.digest` . That is not the digest of the image. This commit fixes it 