### PR TITLE
chore(clamDB): allow manual rebuild

### DIFF
--- a/.github/workflows/clam-db.yaml
+++ b/.github/workflows/clam-db.yaml
@@ -6,6 +6,7 @@ name: Clamav DB
 on:
   schedule:
   - cron: '0 6 * * *'
+  workflow_dispatch:
   push:
     branches: [ main ]
     paths:


### PR DESCRIPTION
Allow to run build workflow manually in case that early rebuild of image is needed.