### PR TITLE
feat(STONEINTG-887): add cosign binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Container image that runs your code
 FROM docker.io/snyk/snyk:linux@sha256:c7f21c3d71f64d592e427e78d5043375c9b93e304f70fdbbd8ca7306cbb0ba1f as snyk
 FROM quay.io/enterprise-contract/ec-cli:snapshot@sha256:141a7cd25ce0d098b1e40fd75d6f75873f8709c5f96f6340993b269c56e3f387 AS ec-cli
+FROM gcr.io/projectsigstore/cosign:v1.13.6@sha256:366bf5a7e882e9748e2b05f620258f8eab89ef4e3597001279291a88486c4fdf as cosign-bin
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3-1612
 
 # Note that the version of OPA used by pr-checks must be updated manually to reflect conftest updates
@@ -46,6 +47,9 @@ ENV PATH="${PATH}:/sbom-utility"
 COPY --from=snyk /usr/local/bin/snyk /usr/local/bin/snyk
 
 COPY --from=ec-cli /usr/bin/ec /usr/local/bin/ec
+
+COPY --from=cosign-bin /ko-app/cosign /usr/local/bin/cosign
+
 
 COPY policies $POLICY_PATH
 COPY test/conftest.sh $POLICY_PATH

--- a/test/selftest.sh
+++ b/test/selftest.sh
@@ -57,6 +57,10 @@ echo "Test presence of ec-cli binary"
 ec version
 check_return_code
 
+echo "Test presence of cosign binary"
+cosign version
+check_return_code
+
 # Test clamscan output format, we are parsing it so we relay on it (including foramt of virus report)
 echo "Test clamscan output format"
 echo "this is for a test" >> /tmp/virus-test.txt


### PR DESCRIPTION
cosing tool is needed to fetch and parse SBOM for the built image

SBOM will be used in deprecated-image-check task